### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @carbynestack/website-maintainers


### PR DESCRIPTION
Subtask of carbynestack/carbynestack#26 for the `corporate-information` repository.

Signed-off-by: Sven Trieflinger <sven.trieflinger@de.bosch.com>